### PR TITLE
Add a way to ignore empty fields

### DIFF
--- a/lib/filters/filter_regex.js
+++ b/lib/filters/filter_regex.js
@@ -81,6 +81,10 @@ FilterRegex.prototype.process = function(data) {
           }
           data['@fields'][this.fields[i]] = v;
         }
+      } else {
+        if (data['@fields'][this.fields[i]]) {
+          delete data['@fields'][this.fields[i]];
+        }
       }
     }
   }

--- a/test/test_202_filter_regex.js
+++ b/test/test_202_filter_regex.js
@@ -65,6 +65,13 @@ vows.describe('Filter regex ').addBatch({
   ], [
     {'@message': 'abcd efgh ijk', '@fields': {fa: 'abcd'}},
   ]),
+  'one field and ignore empty field': filter_helper.create('regex', '?regex=^(\\S+) ((\\d+)|-)&fields=fa,fb,fb', [
+    {'@message': 'abcd 123 ijk'},
+    {'@message': 'abcd - ijk'},
+  ], [
+    {'@message': 'abcd 123 ijk', '@fields': {fa: 'abcd', fb: '123'}},
+    {'@message': 'abcd - ijk', '@fields': {fa: 'abcd'}},
+  ]),
   'date parsing': filter_helper.create('regex', '?regex=^(.*)$&fields=timestamp&date_format=DD/MMMM/YYYY:HH:mm:ss ZZ', [
     {'@message': '31/Jul/2012:18:02:28 +0200'},
     {'@message': '31/Jul/2012'},


### PR DESCRIPTION
This PR add a way to ignore empty parsed fields.

For example, a log line might have a numeric value or a dash:

  ((\d+)|-)

To avoid sending `-` to Elasticsearch and use numeric indexes, the field which will receive the parsed value must be a numeric value or must not be sent to Elasticsearch.

The associated fields must be added twice into the fields list:

  value,value

The first time, it will match the whole expression (i.e. a numeric value or `-`), the second time it will match the numeric value or will be undefined if `-` is present. In that later case, we delete the first matched field.
