### PR TITLE
Assert mutated field is a string before mutating it

### DIFF
--- a/lib/filters/filter_mutate_replace.js
+++ b/lib/filters/filter_mutate_replace.js
@@ -22,7 +22,7 @@ FilterMutateReplace.prototype.afterLoadConfig = function(callback) {
 FilterMutateReplace.prototype.process = function(data) {
   if (data['@fields'] && data['@fields'][this.field_name]) {
     logger.debug('Gsub on field', this.field_name, ', from', this.from, ', to', this.to, ', current value', data['@fields'][this.field_name]);
-    data['@fields'][this.field_name] = data['@fields'][this.field_name].replace(this.regex, this.to);
+    data['@fields'][this.field_name] = new String(data['@fields'][this.field_name]).replace(this.regex, this.to);
     logger.debug('New value', data['@fields'][this.field_name]);
   }
   return data;

--- a/test/test_204_filter_mutate_replace.js
+++ b/test/test_204_filter_mutate_replace.js
@@ -5,6 +5,7 @@ var vows = require('vows'),
 vows.describe('Filter replace ').addBatch({
   'nothing': filter_helper.create('mutate_replace', 'toto?from=\\.&to=-', [{}], [{}]),
   'normal': filter_helper.create('mutate_replace', 'toto?from=\\.&to=-', [{'@fields': {'toto': 'my.domain'}}], [{'@fields': {'toto': 'my-domain'}}]),
+  'float': filter_helper.create('mutate_replace', 'toto?from=\\.&to=-', [{'@fields': {'toto': 10.42}}], [{'@fields': {'toto': '10-42'}}]),
   'multiple': filter_helper.create('mutate_replace', 'toto?from=\\.&to=-', [{'@fields': {'toto': 'my.domain.com'}}], [{'@fields': {'toto': 'my-domain-com'}}]),
   'type_filtering': filter_helper.create(
     'mutate_replace',


### PR DESCRIPTION
The field to mutate might not be a String because node-logstash try to infer if it is an Integer or a Float (from filter_regex.js).

This fix assert the mutation will always process a String.
