### PR TITLE
fdTailer.current_index has string type when start_index is defined on file input

### DIFF
--- a/lib/lib/monitor_file.js
+++ b/lib/lib/monitor_file.js
@@ -197,7 +197,7 @@ MonitoredFile.prototype.restart = function(start_index) {
               }
               else {
                 logger.info('Start reading', this.filename, 'at', start_index, 'fd', fd);
-                this.fdTailer = new FdTailer(fd, start_index, this.options, stats.isFIFO(), this);
+                this.fdTailer = new FdTailer(fd, parseInt(start_index), this.options, stats.isFIFO(), this);
                 this.fdTailer.read();
               }
             }


### PR DESCRIPTION
Defining an input per https://github.com/bpaquet/node-logstash#file with `start_index` set causes it to be typecast as a string when parsed, and so when fdTailer is initialized, its `start_index` also has string type. As can be imagined, adding `buffer_size` each read then concatenates it to `fdTailer.start_index` instead of adding it, making its value ever-increasing lengths of `102410241024...`

This causes two problems:
(1) When any watched file changes, the last data never matches, causing reading to restart
(2) When the `--db_file` flag is set, the JSON object written to that file also has `index=102410241024...`

Fixed by converting `start_index` to an integer when it is defined and used.
