### PR TITLE
Update zmq dependency to 2.3.x as 2.2.0 fails to build on node 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "log4node": "0.1.2",
-    "zmq": "2.2.0",
+    "zmq": "2.3.x",
     "optimist": "0.3.4",
     "moment": "1.7.0"
   },


### PR DESCRIPTION
I was unable to install without first updating the zmq dependency. I believe it's related to binding changes in node 0.10.0 that zmq only addressed after 2.2.0.
