### PR TITLE
Disable connection pooling/keep-alive for elasticsearch output.

### DIFF
--- a/lib/outputs/output_elasticsearch.js
+++ b/lib/outputs/output_elasticsearch.js
@@ -33,6 +33,7 @@ OutputElasticSearch.prototype.process = function(data) {
     port: this.port,
     method: 'POST',
     path: elastic_search_helper.computePath(this.data_type),
+    agent: false,
   };
 
   var json = JSON.stringify(data);


### PR DESCRIPTION
I've had issues with elasticsearch not responding after about five event POSTs. It never fired any error events, nor did it fire the http.request callback.

If there's a better way to fix this I'd love to use it.
