### PR TITLE
Add "format" parameter to UDP input plugin.

### DIFF
--- a/lib/inputs/input_udp.js
+++ b/lib/inputs/input_udp.js
@@ -9,30 +9,54 @@ function InputUdp() {
     name: 'Udp',
     host_field: 'host',
     port_field: 'port',
-    optional_params: ['type', 'source'],
+    optional_params: ['type', 'source', 'format'],
   }
 }
 
 util.inherits(InputUdp, base_input.BaseInput);
 
 InputUdp.prototype.afterLoadConfig = function(callback) {
+  if(this.format &&
+     this.format != 'plain' &&
+     this.format != 'json' &&
+     this.format != 'json_event' &&
+     this.format != 'json_syslog') {
+    return this.emit('init_error', 'Wrong format value: ' + this.format);
+  }
+
   logger.info('Start listening on udp', this.host + ':' + this.port);
 
   this.server = dgram.createSocket('udp4');
 
   this.server.on('message', function(data, remote) {
+    var parsed = {
+      '@message': data.toString().trim(),
+      '@source': this.source || 'udp_' + this.host + '_' + this.port,
+      '@source_host': remote.address,
+      '@type': this.type,
+    };
+
     try {
-      var parsed = JSON.parse(data);
-      this.emit('data', parsed);
+      switch(this.format) {
+        case 'json': // JSON payload, parsed as fields
+          parsed['@fields'] = JSON.parse(data);
+          break;
+        case 'json_syslog': // RFC 3164 compatible message with JSON payload, parsed as fields
+          data = data.toString();
+          parsed['@fields'] = JSON.parse(data.substring(data.indexOf('{', 0)));
+          break;
+        case 'plain': // Plain text, no parsing
+          break;
+        case 'json_event': // JSON message, or fallback to text (legacy behaviour)
+        default:
+          parsed = JSON.parse(data);
+          break;
+      }
     }
     catch(e) {
-      this.emit('data', {
-        '@message': data.toString().trim(),
-        '@source': this.source || 'udp_' + this.host + '_' + this.port,
-        '@source_host': remote.address,
-        '@type': this.type,
-      });
     }
+
+    this.emit('data', parsed);
   }.bind(this));
 
   this.server.on('error', function(err) {


### PR DESCRIPTION
Format parameter can be used to indicate how to parse the input data.
Allowed values are:
- **plain**: Do not try to parse the message received, provide the payload
  as `@message` attribute and fill the other attributes as before.
- **json_event** / **(undefined)** (default): Try to parse the payload as JSON,
  or fallback to plain text (as previous behavior).
- **json**: Try to parse the payload as JSON, filling the `@fields`
  attribute, or fallback to plain text.
- **json_syslog**: Try to parse the payload, starting at first '{', and
  filling the `@fields` attribute, or fallback to plain text
  (compatible with prefixed JSON message, such as for rfc3164 syslog).

The format parameter is meant to work similarly to http://logstash.net/docs/1.1.10/inputs/udp#setting_format and could be generalized to all input plugins.
