### PR TITLE
Support JSON-formatted messages using json_fields filter.

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -404,6 +404,13 @@ Parameters:
 * ``start_line_regex``: egular expression which is used to find lines which start blocks. You have to escape special characters.
 * ``max_delay``: delay to wait the end of a block. Default value: 50 ms. Softwares which write logs by block usually write blocks in one time, this parameter is used to send lines without waiting the next matching start line.
 
+Json Fields
+---
+
+The json fields filter is used to parse the message payload as a JSON object, and merge it to the ``@fields`` attribute. This allows to automatically index fields for messages that already contain a well-formatted JSON payload. The JSON object is parsed starting from the first ``{`` character found in the message. Filter does nothing in case of error while parsing the message. Existing attributes in ``@fields`` are kept, but overwritten if they conflict with attributes from the parsed payload.
+
+Example 1: ``filter://json_fields://?only_type=json_stream`` will parse, as JSON, the given stream of messages which ``@type`` matches ``json_stream``, and fill the ``@fields`` attribute using the messages content.
+
 Misc
 ===
 

--- a/lib/filters/filter_json_fields.js
+++ b/lib/filters/filter_json_fields.js
@@ -1,0 +1,39 @@
+var base_filter = require('../lib/base_filter'),
+    util = require('util'),
+    logger = require('log4node');
+
+function FilterJsonFields() {
+  base_filter.BaseFilter.call(this);
+  this.config = {
+    name: 'JsonFields',
+  }
+}
+
+util.inherits(FilterJsonFields, base_filter.BaseFilter);
+
+FilterJsonFields.prototype.afterLoadConfig = function(callback) {
+  logger.info('Initialized json fields filter');
+  callback();
+}
+
+FilterJsonFields.prototype.process = function(data) {
+  if (!data['@fields']) {
+    data['@fields'] = {};
+  }
+
+  try {
+    var message = data['@message'];
+    var fields = JSON.parse(message.substring(message.indexOf('{', 0)));
+    for (var field in fields) {
+      data['@fields'][field] = fields[field];
+    }
+  }
+  catch(e) {
+  }
+
+  return data;
+}
+
+exports.create = function() {
+  return new FilterJsonFields();
+}

--- a/test/test_212_filter_json_fields.js
+++ b/test/test_212_filter_json_fields.js
@@ -1,0 +1,73 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    moment = require('moment'),
+    patterns_loader = require('../lib/lib/patterns_loader'),
+    filter_helper = require('./filter_helper');
+
+var n = moment();
+
+patterns_loader.add('/toto');
+patterns_loader.add('/tata');
+patterns_loader.add('../lib/patterns');
+
+vows.describe('Filter json_fields ').addBatch({
+  'basic': filter_helper.create('json_fields', '', [
+    {'@message': '{"abcd":"efgh","ijk":["l","m","n"]}'},
+    {'@message': '{"abcd":"ef\\"\\ngh","ijk":["l","m","n"]}'},
+  ], [
+    {'@message': '{"abcd":"efgh","ijk":["l","m","n"]}', '@fields': {abcd: 'efgh', ijk: ['l','m','n']}},
+    {'@message': '{"abcd":"ef\\"\\ngh","ijk":["l","m","n"]}', '@fields': {abcd: 'ef\"\ngh', ijk: ['l','m','n']}},
+  ]),
+  'empty': filter_helper.create('json_fields', '', [
+    {'@message': '{}'},
+    {'@message': '{}', '@fields': {fc: 'toto'}},
+  ], [
+    {'@message': '{}', '@fields': {}},
+    {'@message': '{}', '@fields': {fc: 'toto'}},
+  ]),
+  'merge': filter_helper.create('json_fields', '', [
+    {'@message': '{"abcd":"efgh","ijk":["l","m","n"]}', '@fields': {fc: 'toto'}},
+  ], [
+    {'@message': '{"abcd":"efgh","ijk":["l","m","n"]}', '@fields': {fc: 'toto', abcd: 'efgh', ijk: ['l','m','n']}},
+  ]),
+  'overwrite': filter_helper.create('json_fields', '', [
+    {'@message': '{"abcd":"efgh","ijk":["l","m","n"]}', '@fields': {fc: 'toto', abcd: 'toto'}},
+  ], [
+    {'@message': '{"abcd":"efgh","ijk":["l","m","n"]}', '@fields': {fc: 'toto', abcd: 'efgh', ijk: ['l','m','n']}},
+  ]),
+  'numeric': filter_helper.create('json_fields', '', [
+    {'@message': '{"abcd":0,"ijk":[1,2,3]}'},
+  ], [
+    {'@message': '{"abcd":0,"ijk":[1,2,3]}', '@fields': {abcd: 0, ijk: [1,2,3]}},
+  ]),
+  'object': filter_helper.create('json_fields', '', [
+    {'@message': '{"abcd":{"ef":"g","h":0},"ijk":[1,2,-3.5e-2]}'},
+  ], [
+    {'@message': '{"abcd":{"ef":"g","h":0},"ijk":[1,2,-3.5e-2]}', '@fields': {abcd: {ef: 'g', h: 0}, ijk: [1,2,-0.035]}},
+  ]),
+  'boolean': filter_helper.create('json_fields', '', [
+    {'@message': '{"abcd":true,"efg":false}'},
+  ], [
+    {'@message': '{"abcd":true,"efg":false}', '@fields': {abcd: true, efg: false}},
+  ]),
+  'null': filter_helper.create('json_fields', '', [
+    {'@message': '{"abcd":null}'},
+  ], [
+    {'@message': '{"abcd":null}', '@fields': {abcd: null}},
+  ]),
+  'corner_cases': filter_helper.create('json_fields', '', [
+    {'@message': ''},
+    {'@message': '{'},
+    {'@message': '{[]'},
+    {'@message': '<123>{"abc":"efg"}'},
+    {'@message': '<123>[}'},
+    {'@message': '<123>[]'},
+  ], [
+    {'@message': '','@fields':{}},
+    {'@message': '{','@fields':{}},
+    {'@message': '{[]','@fields':{}},
+    {'@message': '<123>{"abc":"efg"}','@fields':{abc:'efg'}},
+    {'@message': '<123>[}','@fields':{}},
+    {'@message': '<123>[]','@fields':{}},
+  ]),
+}).export(module);


### PR DESCRIPTION
The json_fields plugin will try to parse the message payload as a JSON
object, starting from the first `{` character found in the message.

If successful, the parsed data is merged to the `@fields` attribute,
eventually overwritting existing conflicting-attributes, but keeping
any non-conflicting attribute.

This allows to automatically index the message payload in elasticsearch,
without having to maitain patterns, as long as the logging application
speaks JSON.
