### PR TITLE
Add TLS input and output plugins

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -186,6 +186,27 @@ Parameters:
 * ``pattern_channel``: use channel as pattern. Default value : false
 * ``unserializer``: please see above. Default value to ``json_logstash``.
 
+TLS
+---
+This plugin is used on log server to receive data over TCP with SSL/TLS encryption.
+
+Example:
+
+* ``input://tls://0.0.0.0:443?key=/etc/ssl/private/logstash-server.key&cert=/etc/ssl/private/logstash-server.crt&requestCert=true&rejectUnauthorized=true``
+
+Parameters:
+
+* ``key``: Required. Path to private key in PEM format.
+* ``cert``: Required. Path to SSL certificate in PEM format.
+* ``ca``: Optional. Path to trusted CA certificate file in PEM format. Uses the trusted system CA certificates if omitted/null. Used to authorize client certificates when requestCert and rejectUnauthorized options are true. Default: null
+* ``requestCert``: Optional. If true the server will request a certificate from clients that connect and attempt to verify that certificate. Default: true.
+* ``rejectUnauthorized``: Optional. If true the server will reject any connection which is not authorized with the list of supplied CAs. This option only has an effect if requestCert is true. Default: true.
+* ``appendPeerCert``: Optional. Adds details of the peer certificate to the @tls field if the peer certificate was received from the client using requestCert option. Default: true
+* ``type``: Optional. To specify the log type, to faciliate crawling in kibana. Example: ``type=tls``. No default value.
+* ``unserializer``: Optional. Please see above. Default value to ``json_logstash``.
+
+For more information and examples using SSL certs, refer to the node.js TLS documentation [here](http://nodejs.org/api/tls.html#tls_tls_ssl)
+
 Outputs and filter, commons parameters
 ===
 
@@ -324,6 +345,27 @@ Parameters:
 * ``pattern_channel``: use channel as pattern. Default value : false
 * ``serializer``: please see above. Default value to ``json_logstash``.
 * ``format``: please see above. Used by the ``raw``serializer.
+
+TLS
+---
+
+This plugin is used on log clients to send data over TCP with SSL/TLS encryption.
+
+Example:
+
+* ``output://tls://192.168.1.1:443?key=/etc/ssl/private/logstash-client.key&cert=/etc/ssl/private/logstash-client.crt&rejectUnauthorized=true``
+
+Parameters:
+
+* ``key``: Required. Path to private key in PEM format.
+* ``cert``: Required. Path to SSL certificate in PEM format.
+* ``ca``: Optional. Path to trusted CA certificate file in PEM format. Uses the trusted system CA certificates if omitted/null. Used to authorize the server certificate when rejectUnauthorized option is true. Default: null
+* ``rejectUnauthorized``: Optional. If true the client will abort connection to the server if the server certificate is not authorized with the list of supplied CAs. Default: true.
+* ``secureProtocol``: Optional. The SSL method to use, e.g. SSLv3\_method to force SSL version 3. The possible values depend on your installation of OpenSSL and are defined in the constant [SSL_METHODS](http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS). Default: SSLv3\_method
+* ``serializer``: Optional. Please see above. Default value to ``json_logstash``.
+* ``format``: Optional. Please see above. Used by the ``raw``serializer.
+
+For more information and examples using SSL certs, refer to the node.js TLS documentation [here](http://nodejs.org/api/tls.html#tls_tls_ssl)
 
 Filters
 ===

--- a/lib/inputs/input_tls.js
+++ b/lib/inputs/input_tls.js
@@ -1,0 +1,88 @@
+var base_input = require('../lib/base_input'),
+    tls = require('tls'),
+    fs = require('fs'),
+    util = require('util'),
+    logger = require('log4node');
+
+function InputTls() {
+  base_input.BaseInput.call(this);
+  this.config = {
+    name: 'Tls',
+    host_field: 'host',
+    port_field: 'port',
+    required_params: ['key', 'cert'],
+    optional_params: ['type', 'unserializer', 'ca', 'requestCert', 'rejectUnauthorized', 'appendPeerCert'],
+    default_values: {
+      'type': null,
+      'unserializer': 'json_logstash',
+      'ca': null,
+      'requestCert': 'true',
+      'rejectUnauthorized': 'true',
+      'appendPeerCert': 'true'
+    }
+  }
+}
+
+util.inherits(InputTls, base_input.BaseInput);
+
+InputTls.prototype.afterLoadConfig = function(callback) {
+  logger.info('Start listening on tls', this.host + ':' + this.port);
+
+  var tls_options = { host: this.host,
+                      port: this.port,
+                      key: fs.readFileSync(this.key),
+                      cert: fs.readFileSync(this.cert),
+                      ca: this.ca ? fs.readFileSync(this.ca) : null,
+                      requestCert: this.requestCert.toLowerCase() == 'false' ? false : true,
+                      rejectUnauthorized: this.rejectUnauthorized.toLowerCase() == 'false' ? false : true,
+                      appendPeerCert: this.appendPeerCert.toLowerCase() == 'false' ? false : true
+  }
+
+  this.configure_unserialize(this.unserializer);
+
+  this.server = tls.createServer(tls_options, function(c) {
+    c.on('data', function(data) {
+      this.unserialize_data(data, function(parsed) {
+        this.emit('data', parsed);
+      }.bind(this), function(data) {
+        var peerCert = {};
+
+        if (tls_options['appendPeerCert']) {
+          peerCert = c.getPeerCertificate();
+          delete peerCert['modulus'] && delete peerCert['exponent']
+        }
+
+        var tls_info = { 'authorized': c.authorized,
+                         'peer_cert': peerCert
+        }
+
+        this.emit('data', {
+          '@message': data.toString().trim(),
+          '@source': 'tls_' + this.host + '_' + this.port,
+          '@tls': tls_info,
+          '@type': this.type,
+        });
+      }.bind(this));
+    }.bind(this));
+    c.on('error', function(err) {
+      this.emit('error', err);
+    }.bind(this));
+  }.bind(this));
+
+  this.server.on('error', function(err) {
+    this.emit('init_error', err);
+  }.bind(this));
+
+  this.server.listen(this.port, this.host);
+
+  this.server.once('listening', callback);
+}
+
+InputTls.prototype.close = function(callback) {
+  logger.info('Closing listening tls', this.host + ':' + this.port);
+  this.server.close(callback);
+}
+
+exports.create = function() {
+  return new InputTls();
+}

--- a/lib/outputs/output_tls.js
+++ b/lib/outputs/output_tls.js
@@ -1,0 +1,65 @@
+var base_output = require('../lib/base_output'),
+    util = require('util'),
+    tls = require('tls'),
+    fs = require('fs'),
+    logger = require('log4node'),
+    error_buffer = require('../lib/error_buffer');
+
+function OutputTLS() {
+  base_output.BaseOutput.call(this);
+  this.config = {
+    name: 'Tls',
+    host_field: 'host',
+    port_field: 'port',
+    optional_params: ['error_buffer_delay', 'format', 'serializer', 'key', 'cert', 'ca', 'rejectUnauthorized', 'secureProtocol'],
+    default_values: {
+      'error_buffer_delay': 10000,
+      'format': '#{@message}',
+      'serializer': 'json_logstash',
+      'key': null,
+      'cert': null,
+      'ca': null,
+      'rejectUnauthorized': true,
+      'secureProtocol': 'SSLv3_method'
+    }
+  }
+}
+
+util.inherits(OutputTLS, base_output.BaseOutput);
+
+OutputTLS.prototype.afterLoadConfig = function(callback) {
+  logger.info('Start output to tls', this.host + ':' + this.port);
+
+  this.configure_serialize(this.serializer, this.format);
+
+  this.error_buffer = error_buffer.create('output tls to ' + this.host + ':' + this.port, this.error_buffer_delay, this);
+  callback();
+}
+
+OutputTLS.prototype.process = function(data) {
+  var tls_options = { host: this.host,
+                      port: this.port,
+                      key: fs.readFileSync(this.key),
+                      cert: fs.readFileSync(this.cert),
+                      ca: this.ca ? fs.readFileSync(this.ca) : null,
+                      rejectUnauthorized: this.rejectUnauthorized.toLowerCase() == 'false' ? false : true,
+                      secureProtocol: this.secureProtocol
+  }
+
+  var c = tls.connect(tls_options, function() {
+    c.write(this.serialize_data(data));
+    c.end();
+  }.bind(this));
+  c.on('error', function(err) {
+    this.error_buffer.emit('error', err);
+  }.bind(this));
+}
+
+OutputTLS.prototype.close = function(callback) {
+  logger.info('Closing output to tls', this.host + ':' + this.port);
+  callback();
+}
+
+exports.create = function() {
+  return new OutputTLS();
+}


### PR DESCRIPTION
Add TLS input and output plugins. 

In the future, perhaps TLS functionality should be patched into the tcp input/outputs in order to behave more like the logstash.net TCP+SSL transport (http://logstash.net/docs/1.1.13/inputs/tcp). For now I have put the TLS functionality into these separate plugins.
