### PR TITLE
Make sure 'type' is an optional parameter in input_redis

### DIFF
--- a/lib/inputs/input_redis.js
+++ b/lib/inputs/input_redis.js
@@ -15,7 +15,7 @@ function InputRedis() {
     host_field: 'host',
     port_field: 'port',
     required_params: ['channel'],
-    optional_params: ['pattern_channel', 'retry'],
+    optional_params: ['type', 'pattern_channel', 'retry'],
     default_values: {
       'type': null,
       'pattern_channel': false,


### PR DESCRIPTION
I ran into a what seems to be a bug with the redis input component. the "type" parameter is not taken into account.

I hope this is the correct way to fix this !
