### PR TITLE
Add a newline after JSON serialization (fixes issue #52)

### DIFF
--- a/lib/lib/base_output.js
+++ b/lib/lib/base_output.js
@@ -29,7 +29,7 @@ BaseOutput.prototype.init = function(url, callback) {
 BaseOutput.prototype.configure_serialize = function(serializer, raw_format) {
   if (serializer === 'json_logstash') {
     this.serialize_data = function(data) {
-      return JSON.stringify(data);
+      return JSON.stringify(data) + '\n';
     };
   }
   else if (serializer === 'raw') {


### PR DESCRIPTION
In the case 'json_logstash' serializer is used, have the serialize_data() method append a newline to the result of the serialization.

Adding this newline has the effect of producing content that will be readable by logstash, as logstash needs to parse content line by line.
