### PR TITLE
Default to using UTC for index names, same as Logstash and Kibana.

### DIFF
--- a/lib/lib/elastic_search_helper.js
+++ b/lib/lib/elastic_search_helper.js
@@ -5,9 +5,9 @@ function fill0(s, k) {
 
 function formatDate() {
   var now = new Date();
-  var year = now.getFullYear();
-  var month = fill0((now.getMonth() + 1) + '', 2);
-  var day = fill0((now.getDate()) + '', 2);
+  var year = now.getUTCFullYear();
+  var month = fill0((now.getUTCMonth() + 1) + '', 2);
+  var day = fill0((now.getUTCDate()) + '', 2);
   return year + '.' + month + '.' + day;
 }
 


### PR DESCRIPTION
Although there is a [request](https://logstash.jira.com/browse/LOGSTASH-973) for indexes to be rolled over
at midnight local time, until logstash provides that as an option
it seems like node-logstash should have matching behavoir.
