### PR TITLE
Consistently respect `only_type` and `only_field_*` params

### DIFF
--- a/lib/lib/base_component.js
+++ b/lib/lib/base_component.js
@@ -79,18 +79,19 @@ BaseComponent.prototype.runHooks = function(list, callback) {
 };
 
 BaseComponent.prototype.loadConfig = function(url, callback) {
+  logger.debug('Loading config url: \"' + url + '\"');
   this.message_filtering = {};
   
   var val, i, res;
 
   if (url.length === 0) {
-    return callback(new Error('No empty url for ' + this.config.name));
-  }
-
-  this.parsed_url = url_parser.processUrlContent(url);
+    this.parsed_url = {params:{}};
+  }else{
+    this.parsed_url = url_parser.processUrlContent(url);
   
-  if (!this.parsed_url) {
-    return callback(new Error('Unable to parse config : ' + url));
+    if (!this.parsed_url) {
+      return callback(new Error('Unable to parse config : ' + url));
+    }
   }
 
   if (this.config.host_field) {


### PR DESCRIPTION
This fixes around a bug in `BaseComponent.prototype.loadConfig` where
your config won't be processed unless your filter has some specific
configuration.

`only_type` and `only_field_*` params are implicitly processed by
`BaseComponent.prototype.loadConfig`, but `loadConfig` has a "do we
need to load config" check at the top of the function that might fail,
at which point the implicit options is ignored.

For example, a custom filter
`filter://my_thing://only_type=syslog`. `my_thing` doesn't need any
other parameters, so it's constructor looks like

``` js
function FilterMyThing() {
  base_filter.BaseFilter.call(this);
  this.mergeConfig({
    name: 'MyThing'
  });
}
```

In the previous implementation, `BaseComponent.prototype.loadConfig`
will decide no config needs to be loaded, ignore the `only_type`
param, and `my_thing` filter will apply to all messages.

This patch removes the if statement, and re-indents. The `loadConfig`
function is only called once when the filter is loaded, so any
performance penalty by processing all the options is a one-time cost.
