### PR TITLE
add kafka input/output plugins using kafka-node

### DIFF
--- a/lib/inputs/input_kafka.js
+++ b/lib/inputs/input_kafka.js
@@ -1,0 +1,86 @@
+var base_input = require('../lib/base_input'),
+  util = require('util'),
+  kafka = require('kafka-node'),
+  logger = require('log4node');
+
+function InputKafka() {
+  base_input.BaseInput.call(this);
+  this.mergeConfig(this.unserializer_config());
+  this.mergeConfig({
+    name: 'Kafka',
+    host_field: 'connectionString',
+    optional_params: ['type', 'clientId', 'zkOptions', 'topics', 'groupId', 'autoCommitIntervalMs', 'fetchMaxWaitMs', 'fetchMinBytes', 'fetchMaxBytes', 'fromOffset', 'encoding'],
+    default_values: {
+      type: 'kafka',
+      topics: 'logstash',
+      groupId: 'kafka-logstash-group', //consumer group id, deafult `kafka-node-group`
+      autoCommitIntervalMs: 5000,  // Auto commit config
+      fetchMaxWaitMs: 100,         // The max wait time is the maximum amount of time in milliseconds to block waiting if insufficient data is available at the time the request is issued, default 100ms
+      fetchMinBytes: 1,            // This is the minimum number of bytes of messages that must be available to give a response, default 1 byte
+      fetchMaxBytes: 1024 * 10,    // The maximum bytes to include in the message set for this partition. This helps bound the size of the response.
+      fromOffset: false,           // If set true, consumer will fetch message from the given offset in the payloads
+      encoding: 'utf8'             // If set to 'buffer', values will be returned as raw buffer objects.
+    },
+    start_hook: this.start,
+  });
+}
+
+util.inherits(InputKafka, base_input.BaseInput);
+
+InputKafka.prototype.start = function(callback) {
+  logger.info(util.format('Start listening on kafka connectionString: %s, topics: %s', this.connectionString, this.topics));
+
+  this.client = new kafka.Client(this.connectionString);
+
+  var payloads = this.topics.split(',').map(function(topic) {return {topic: topic.trim()};});
+  var options = {
+    groupId: this.groupId,
+    autoCommitIntervalMs: this.autoCommitIntervalMs,
+    fetchMaxWaitMs: this.fetchMaxWaitMs,
+    fetchMinBytes: this.fetchMinBytes,
+    fetchMaxBytes: this.fetchMaxBytes,
+    fromOffset: this.fromOffset,
+    encoding: this.encoding
+  };
+
+  this.consumer = new kafka.HighLevelConsumer(this.client, payloads, options);
+
+  this.consumer.on('message', function(data) {
+    this.unserialize_data(data.value, function(parsed) {
+      if (this.type) {
+        parsed.type = this.type;
+      }
+      //logger.info(parsed);
+      this.emit('data', parsed);
+    }.bind(this), function(data) {
+      var obj = {
+        'message': data.toString().trim(),
+        'kafka_from': this.connectionString,
+        'type': this.type,
+      };
+      this.emit('data', obj);
+    }.bind(this));
+  }.bind(this));
+
+  // TODO: better handling of these errors...
+  this.consumer.on('error', function(err) {
+    logger.error(err);
+  });
+  this.consumer.on('offsetOutOfRange', function(err) {
+    logger.error(err);
+  });
+
+  this.consumer.on('ready', function() {
+    logger.info(util.format('Connected and listening on kafka connectionString: %s, topics: %s', this.connectionString, this.topics));
+    return callback();
+  }.bind(this));
+};
+
+InputKafka.prototype.close = function(callback) {
+  logger.info(util.format('Closing input from kafka connectionString: %s, topics: %s', this.connectionString, this.topics));
+  this.client.close(callback);
+};
+
+exports.create = function() {
+  return new InputKafka();
+};

--- a/lib/outputs/abstract_kafka.js
+++ b/lib/outputs/abstract_kafka.js
@@ -1,0 +1,53 @@
+var base_output = require('../lib/base_output'),
+  util = require('util'),
+  kafka = require('kafka-node'),
+  logger = require('log4node');
+
+function AbstractKafka() {
+  base_output.BaseOutput.call(this);
+  this.mergeConfig({
+    name: 'Abstract Kafka',
+    host_field: 'connectionString',
+    optional_params: ['clientId', 'zkOptions', 'topic'],
+    default_values: {
+      clientId: 'node-logstash-output',
+      topic: 'logstash'
+    },
+    start_hook: this.startAbstract,
+  });
+}
+
+util.inherits(AbstractKafka, base_output.BaseOutput);
+
+AbstractKafka.prototype.startAbstract = function(callback) {
+  logger.info('Start output to', this.connectionString, 'using kafka-node');
+
+  this.client = new kafka.Client(this.connectionString);
+  this.producer = new kafka.HighLevelProducer(this.client);
+  if (!this.topic) {
+    this.topic = 'logstash';
+  }
+  this.producer.on('ready', callback);
+};
+
+AbstractKafka.prototype.process = function(data) {
+  this.formatPayload(data, function(message) {
+    var payload = [{topic: this.topic, messages: message}]
+    this.producer.send(payload, function(err, data) {
+      if (err) {
+        // TODO: go into alarm mode?
+        logger.error(err);
+      }
+      else {
+        logger.debug(data);
+      }
+    });
+  }.bind(this));
+};
+
+AbstractKafka.prototype.close = function(callback) {
+  logger.info('Closing output to kafka', this.connectionString);
+  this.client.close(callback);
+};
+
+exports.AbstractKafka = AbstractKafka;

--- a/lib/outputs/output_kafka.js
+++ b/lib/outputs/output_kafka.js
@@ -1,0 +1,24 @@
+var abstract_zeromq = require('./abstract_kafka'),
+  util = require('util');
+
+function OutputKafka() {
+  abstract_zeromq.AbstractKafka.call(this);
+  this.mergeConfig(this.serializer_config());
+  this.mergeConfig({
+    name: 'Kafka',
+  });
+}
+
+util.inherits(OutputKafka, abstract_zeromq.AbstractKafka);
+
+OutputKafka.prototype.to = function() {
+  return 'Kafka : ' + this.target;
+};
+
+OutputKafka.prototype.formatPayload = function(data, callback) {
+  callback(this.serialize_data(data));
+};
+
+exports.create = function() {
+  return new OutputKafka();
+};

--- a/lib/outputs/output_kafka_river.js
+++ b/lib/outputs/output_kafka_river.js
@@ -1,0 +1,44 @@
+var abstract_kafka = require('./abstract_kafka'),
+  util = require('util'),
+  moment = require('moment');
+
+function OutputKafkaRiver() {
+  abstract_kafka.AbstractKafka.call(this);
+  this.mergeConfig(this.serializer_config());
+  this.mergeConfig({
+    name: 'Kafka River',
+    optional_params: ['index_prefix', 'data_type', 'date_format', 'id_field'],
+    default_values: {
+      index_prefix: 'logstash',
+      data_type: 'logs',
+      date_format: 'YYYY-MM-DD'
+    },
+  });
+}
+
+util.inherits(OutputKafkaRiver, abstract_kafka.AbstractKafka);
+
+OutputKafkaRiver.prototype.to = function() {
+  return 'Elasticsearch Kafka : ' + this.target;
+};
+
+OutputKafkaRiver.prototype.formatPayload = function(data, callback) {
+  var date = moment.utc();
+  if (data['@timestamp']) {
+    date = moment(data['@timestamp']);
+  }
+  var index = util.format('%s-%s', this.index_prefix, date.format(this.date_format));
+  var doc = {
+    index: index,
+    type: this.data_type,
+    source: data
+  };
+  if (this.id_field) {
+    doc.id = data[this.id_field];
+  }
+  return callback(JSON.stringify(doc));
+};
+
+exports.create = function() {
+  return new OutputKafkaRiver();
+};

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "oniguruma": "4.0.x",
     "msgpack": "0.2.6",
     "geoip-lite": "1.1.x",
-    "proxying-agent": "0.1.x"
+    "proxying-agent": "0.1.x",
+    "kafka-node": "0.2.x"
   },
   "directories": {
     "test": "./test",


### PR DESCRIPTION
I know more is needed for this (like testing...), but this is the beginnings of a kafka input/output plugin.  This is using https://github.com/SOHU-Co/kafka-node/ and the HighLevelProducer/HighLevelConsumer interfaces to produce/consume messages to kafka topics.  On the output side, I also created a `kafka_river` output that is the same as the `kafka` output but formats the messages published to kafka with an JSON envelope that can be indexed into ElasticSearch with the https://github.com/clippPR/elasticsearch-river-kafka ES river.  An example of this JSON envelope structure can be seen here: https://github.com/clippPR/elasticsearch-river-kafka/blob/master/src/main/java/org/elasticsearch/river/kafka/JsonMessageHandler.java#L35

One thing I wasn't completely sure of was whether to have the `kafka_river` as a separate output type or have it be a filter.  I ended up following the example of the `output_elasticsearch_zeromq`.