### PR TITLE
Add raw unserializer to base input (performance)

### DIFF
--- a/lib/lib/base_input.js
+++ b/lib/lib/base_input.js
@@ -20,6 +20,9 @@ BaseInput.prototype.configure_unserialize = function(serializer) {
   if (serializer === 'json_logstash') {
     this.unserialize_data = this.unserialize_data_json;
   }
+  else if (serializer === 'raw') {
+    this.unserialize_data = this.unserialize_data_raw;
+  }
   else if (serializer === 'msgpack') {
     this.msgpack = this.requireLib('msgpack');
     this.unserialize_data = this.unserialize_data_msgpack;
@@ -27,6 +30,10 @@ BaseInput.prototype.configure_unserialize = function(serializer) {
   else {
     throw new Error('Unknown serializer ' + serializer);
   }
+};
+
+BaseInput.prototype.unserialize_data_raw = function(data, ok_callback, parse_fail_callback) {
+  parse_fail_callback(data);
 };
 
 BaseInput.prototype.unserialize_data_json = function(data, ok_callback, parse_fail_callback) {
@@ -70,7 +77,7 @@ BaseInput.prototype.unserializer_config = function() {
     start_hook: function(callback) {
       this.configure_unserialize(this.unserializer);
       callback();
-    },
+    }.bind(this),
   };
 };
 

--- a/test/test_410_file2x2x2file.js
+++ b/test/test_410_file2x2x2file.js
@@ -6,7 +6,7 @@ var vows = require('vows-batch-retry'),
   monitor_file = require('lib/monitor_file'),
   redis_driver = require('redis_driver');
 
-function _file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, check, wait_delay) {
+function _file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, check, wait_delay, extra_input) {
   return {
     topic: function() {
       start_callback = start_callback || function(callback) {
@@ -21,7 +21,7 @@ function _file2x2x2file(config1, config2, clean_callback, start_callback, stop_c
       var callback = this.callback;
       start_callback(function(o) {
         monitor_file.setFileStatus({});
-        helper.createAgent(['input://file://main_input.txt?type=test'].concat(config1), function(a1) {
+        helper.createAgent(['input://file://main_input.txt?type=test'+(extra_input ? extra_input : '')].concat(config1), function(a1) {
           helper.createAgent(config2.concat(['output://file://main_output.txt?serializer=json_logstash']), function(a2) {
             setTimeout(function() {
               fs.appendFile('main_input.txt', '234 tgerhe grgh\néè\nline3\n', function(err) {
@@ -62,8 +62,8 @@ function _file2x2x2file(config1, config2, clean_callback, start_callback, stop_c
   };
 }
 
-function file2x2x2fileNotOrdered(config1, config2, clean_callback, start_callback, stop_callback, wait_delay) {
-  return _file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, function(splitted) {
+function file2x2x2fileNotOrdered(config1, config2, clean_callback, start_callback, stop_callback, wait_delay, extra_input) {
+  return _file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, extra_input, function(splitted) {
     splitted.sort();
     helper.checkResult(splitted[0], {
       'path': path.resolve('.') + '/main_input.txt',
@@ -86,8 +86,8 @@ function file2x2x2fileNotOrdered(config1, config2, clean_callback, start_callbac
   }, wait_delay);
 }
 
-function file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, wait_delay) {
-  return _file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, function(splitted) {
+function file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, wait_delay, extra_input) {
+  return _file2x2x2file(config1, config2, clean_callback, start_callback, stop_callback, extra_input, function(splitted) {
     helper.checkResult(splitted[0], {
       'path': path.resolve('.') + '/main_input.txt',
       'message': '234 tgerhe grgh',
@@ -161,6 +161,12 @@ var test = vows.describe('Integration file2x2x2file :').addBatchRetry({
     }
   }),
 }, 5, 20000).addBatchRetry({
+  'file transport raw input': file2x2x2file(['output://file://main_middle.txt?serializer=json_logstash'], ['input://file://main_middle.txt'], function() {
+    if (fs.existsSync('main_middle.txt')) {
+      fs.unlinkSync('main_middle.txt');
+    }
+  }, undefined, undefined, undefined, '&unserializer=raw'),
+}, 5, 20000).addBatchRetry({
   'tcp transport': file2x2x2file(['output://tcp://localhost:17874'], ['input://tcp://0.0.0.0:17874']),
 }, 5, 20000).addBatchRetry({
   'zeromq transport': file2x2x2file(['output://zeromq://tcp://localhost:17874'], ['input://zeromq://tcp://*:17874']),
@@ -196,6 +202,3 @@ if (fs.existsSync('.sqs')) {
 }
 
 test.export(module);
-
-
-


### PR DESCRIPTION
For performance reasons, it is better not to try to parse lines from a log file where we know in advance that the file contains lines that are NOT json. 
This can be achieved by specifying the new "raw" unserializer which simply passes the read line to the input handler.