### PR TITLE
Add Websocket input/output

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -168,6 +168,7 @@ Inputs
 * [ZeroMQ](#zeromq)
 * [Redis](#redis)
 * [HTTP](#http)
+* [Websocket](#websocket)
 * [TCP / TLS](#tcp--tls)
 * [Google app engine](#google-app-engine)
 * [AMQP](#amqp)
@@ -202,6 +203,7 @@ Outputs
 * [Gelf](#gelf)
 * [File](#file-1)
 * [HTTP Post](#http-post)
+* [Websocket](#websocket-1)
 * [Redis](#redis-1)
 * [Logio](#logio)
 * [TCP / TLS](#tcp--tls-1)
@@ -305,7 +307,8 @@ HTTP
 ---
 
 This plugin is used on log server to receive logs from an HTTP/HTTPS stream. This is useful
-in case the agent can only output logs through an HTTP/HTTPS channel.
+in case the agent can only output logs through an HTTP/HTTPS channel. Consider using websocket as it is much faster
+than HTTP.
 
 Example:
 
@@ -316,6 +319,23 @@ Parameters:
 * ``type``: to specify the log type, to faciliate crawling in kibana. Example: ``type=http``. No default value.
 * ``unserializer``: please see above. Default value to ``json_logstash``.
 * ``ssl``: enable SSL mode. See below for SSL parameters. Default : false
+
+Websocket
+---
+This plugin is used on log server to receive data over a websocket, optionally with SSL/TLS encryption. Websockets are
+like TCP, but are proxy and firewall friendly.
+
+Examples:
+
+* Regular mode: ``input://websocket://0.0.0.0:12345``
+* TLS mode: ``input://websocket://0.0.0.0:443?ssl=true&ssl_key=/etc/ssl/private/logstash-server.key&ssl_cert=/etc/ssl/private/logstash-server.crt&ssl_requestCert=true&ssl_rejectUnauthorized=true``
+
+Parameters:
+
+* ``ssl``: enable SSL mode. See below for SSL parameters. Default : false
+* ``appendPeerCert``: Optional. In SSL mode, adds details of the peer certificate to the @tls field if the peer certificate was received from the client using requestCert option. Default: true in SSL mode
+* ``type``: Optional. To specify the log type, to faciliate crawling in kibana. Example: ``type=tls``. No default value.
+* ``unserializer``: Optional. Please see above. Default value to ``json_logstash``.
 
 TCP / TLS
 ---
@@ -529,6 +549,24 @@ Parameters:
 * ``path``: path to use in the HTTP request. Can reference log line properties (see above).
 * ``serializer``: please see above. Default value to ``json_logstash``.
 * ``format``: please see above. Used by the ``raw``serializer.
+* ``ssl``: enable SSL mode. See below for SSL parameters. Default : false
+* ``proxy``: use http proxy. See below for HTTP proxy. Default : none.
+
+Websocket
+---
+
+This plugin is used on log clients to send data over a websocket, optionally with SSL/TLS encryption. Websockets are like
+TCP connections but they are proxy and firewall friendly.
+
+Example:
+
+* Regular mode:  ``output://webocket://192.168.1.1:12345``
+* TLS Mode: ``output://webocket://192.168.1.1:443?ssl=true&ssl_key=/etc/ssl/private/logstash-client.key&ssl_cert=/etc/ssl/private/logstash-client.crt&ssl_rejectUnauthorized=true``
+
+Parameters:
+
+* ``serializer``: Optional. Please see above. Default value to ``json_logstash``.
+* ``format``: Optional. Please see above. Used by the ``raw``serializer.
 * ``ssl``: enable SSL mode. See below for SSL parameters. Default : false
 * ``proxy``: use http proxy. See below for HTTP proxy. Default : none.
 

--- a/lib/inputs/input_websocket.js
+++ b/lib/inputs/input_websocket.js
@@ -14,7 +14,10 @@ function InputWebsocket() {
     name: 'Websocket',
     host_field: 'host',
     port_field: 'port',
-    optional_params: ['type'],
+    optional_params: ['type', 'path'],
+    default_values: {
+      'path': '/',
+    },
     start_hook: this.start,
   });
 }
@@ -34,7 +37,7 @@ InputWebsocket.prototype.start = function(callback) {
     this.server = http.createServer();
   }
 
-  this.wss = new WebSocketServer({ server: this.server });
+  this.wss = new WebSocketServer({ server: this.server, path: this.path });
   this.wss.on('connection', function(ws) {
 
     ws.on('message', function(data) {

--- a/lib/inputs/input_websocket.js
+++ b/lib/inputs/input_websocket.js
@@ -26,7 +26,7 @@ InputWebsocket.prototype.start = function(callback) {
 
   if (this.ssl) {
     this.server = https.createServer(ssl_helper.merge_options(this, {}));
-    server.on('clientError', function(err) {
+    this.server.on('clientError', function(err) {
       this.emit('error', err);
     }.bind(this));
   }
@@ -70,7 +70,7 @@ InputWebsocket.prototype.close = function(callback) {
   this.wss.close();
   this.server.close(function() {
     callback();
-  })
+  });
 };
 
 exports.create = function() {

--- a/lib/inputs/input_websocket.js
+++ b/lib/inputs/input_websocket.js
@@ -1,0 +1,77 @@
+var base_input = require('../lib/base_input'),
+  util = require('util'),
+  http = require('http'),
+  https = require('https'),
+  WebSocketServer = require('ws').Server,
+  ssl_helper = require('../lib/ssl_helper'),
+  logger = require('log4node');
+
+function InputWebsocket() {
+  base_input.BaseInput.call(this);
+  this.mergeConfig(ssl_helper.config());
+  this.mergeConfig(this.unserializer_config());
+  this.mergeConfig({
+    name: 'Websocket',
+    host_field: 'host',
+    port_field: 'port',
+    optional_params: ['type'],
+    start_hook: this.start,
+  });
+}
+
+util.inherits(InputWebsocket, base_input.BaseInput);
+
+InputWebsocket.prototype.start = function(callback) {
+  logger.info('Start listening on websocket', this.host + ':' + this.port, 'ssl ' + this.ssl);
+
+  var server;
+  if (this.ssl) {
+    server = https.createServer(ssl_helper.merge_options(this, {}));
+    server.on('clientError', function(err) {
+      this.emit('error', err);
+    }.bind(this));
+  }
+  else {
+    server = http.createServer();
+  }
+
+  this.wss = new WebSocketServer({ server: server });
+  this.wss.on('connection', function(ws) {
+
+    ws.on('message', function(data) {
+      this.unserialize_data(data, function(parsed) {
+        this.emit('data', parsed);
+      }.bind(this), function(data) {
+        this.emit('data', {
+          'message': data.trim(),
+          'host': ws._socket.remoteAddress,
+          'ws_port': this.port,
+          'type': this.type,
+        });
+      }.bind(this));
+    }.bind(this));
+
+    ws.on('error', function(err) {
+      this.emit('error', err);
+    }.bind(this));
+
+  }.bind(this));
+
+  this.wss.on('error', function(err) {
+    this.emit('error', err);
+  }.bind(this));
+
+  server.once('listening', callback);
+  server.listen(this.port, this.host);
+};
+
+InputWebsocket.prototype.close = function(callback) {
+  logger.info('Closing websocket server', this.host + ':' + this.port, 'ssl ' + this.ssl);
+  // close the server and terminate all clients
+  this.wss.close();
+  callback();
+};
+
+exports.create = function() {
+  return new InputWebsocket();
+};

--- a/lib/inputs/input_websocket.js
+++ b/lib/inputs/input_websocket.js
@@ -24,18 +24,17 @@ util.inherits(InputWebsocket, base_input.BaseInput);
 InputWebsocket.prototype.start = function(callback) {
   logger.info('Start listening on websocket', this.host + ':' + this.port, 'ssl ' + this.ssl);
 
-  var server;
   if (this.ssl) {
-    server = https.createServer(ssl_helper.merge_options(this, {}));
+    this.server = https.createServer(ssl_helper.merge_options(this, {}));
     server.on('clientError', function(err) {
       this.emit('error', err);
     }.bind(this));
   }
   else {
-    server = http.createServer();
+    this.server = http.createServer();
   }
 
-  this.wss = new WebSocketServer({ server: server });
+  this.wss = new WebSocketServer({ server: this.server });
   this.wss.on('connection', function(ws) {
 
     ws.on('message', function(data) {
@@ -61,15 +60,17 @@ InputWebsocket.prototype.start = function(callback) {
     this.emit('error', err);
   }.bind(this));
 
-  server.once('listening', callback);
-  server.listen(this.port, this.host);
+  this.server.once('listening', callback);
+  this.server.listen(this.port, this.host);
 };
 
 InputWebsocket.prototype.close = function(callback) {
   logger.info('Closing websocket server', this.host + ':' + this.port, 'ssl ' + this.ssl);
   // close the server and terminate all clients
   this.wss.close();
-  callback();
+  this.server.close(function() {
+    callback();
+  })
 };
 
 exports.create = function() {

--- a/lib/outputs/output_websocket.js
+++ b/lib/outputs/output_websocket.js
@@ -12,6 +12,10 @@ function OutputWebsocket() {
   }));
   this.mergeConfig({
     name: 'Websocket',
+    optional_params: ['path'],
+    default_values: {
+      'path': '/',
+    },
   });
 }
 
@@ -48,7 +52,10 @@ OutputWebsocket.prototype.startAbstract = function(callback) {
 
 OutputWebsocket.prototype.connect = function() {
   var protocol = this.ssl ? 'wss' : 'ws';
-  var ws_options = {};
+  var ws_options = {
+    path: this.path
+  };
+
   if (this.proxying_agent) {
     ws_options.agent = this.proxying_agent;
   }

--- a/lib/outputs/output_websocket.js
+++ b/lib/outputs/output_websocket.js
@@ -52,14 +52,12 @@ OutputWebsocket.prototype.startAbstract = function(callback) {
 
 OutputWebsocket.prototype.connect = function() {
   var protocol = this.ssl ? 'wss' : 'ws';
-  var ws_options = {
-    path: this.path
-  };
+  var ws_options = {};
 
   if (this.proxying_agent) {
     ws_options.agent = this.proxying_agent;
   }
-  var ws = new WebSocket(protocol + '://' + this.host + ':' + this.port, ws_options);
+  var ws = new WebSocket(protocol + '://' + this.host + ':' + this.port + this.path, ws_options);
 
   ws.on('open', function() {
     this.open = true;

--- a/lib/outputs/output_websocket.js
+++ b/lib/outputs/output_websocket.js
@@ -1,0 +1,96 @@
+var abstract_http = require('./abstract_http'),
+  util = require('util'),
+  logger = require('log4node'),
+  error_buffer = require('../lib/error_buffer'),
+  WebSocket = require('ws');
+
+function OutputWebsocket() {
+  abstract_http.AbstractHttp.call(this);
+  this.mergeConfig(this.serializer_config('raw'));
+  this.mergeConfig(error_buffer.config(function() {
+    return 'output websocket to ' + this.host + ':' + this.port;
+  }));
+  this.mergeConfig({
+    name: 'Websocket',
+  });
+}
+
+util.inherits(OutputWebsocket, abstract_http.AbstractHttp);
+
+OutputWebsocket.prototype.process = function(data) {
+  var line = this.serialize_data(data);
+  if (this.open) {
+    this.send(line);
+  } else {
+    this.pending.push(line);
+  }
+};
+
+OutputWebsocket.prototype.send = function(line) {
+  this.ws.send(line, function ack(err) {
+    if (err) {
+      this.error_buffer.emit('error', err);
+    }
+  });
+};
+
+OutputWebsocket.prototype.startAbstract = function(callback) {
+  logger.info('Start websocket output to',this.host + ':' + this.port);
+
+  if (this.proxy) {
+    this.setupProxy();
+  }
+
+  this.pending = [];
+  this.connect();
+  callback();
+};
+
+OutputWebsocket.prototype.connect = function() {
+  var protocol = this.ssl ? 'wss' : 'ws';
+  var ws_options = {};
+  if (this.proxying_agent) {
+    ws_options.agent = this.proxying_agent;
+  }
+  var ws = new WebSocket(protocol + '://' + this.host + ':' + this.port, ws_options);
+
+  ws.on('open', function() {
+    this.open = true;
+    this.error_buffer.emit('ok');
+    if (this.pending.length > 0) {
+      this.pending.forEach(function(line) {
+        this.send(line);
+      }.bind(this));
+      this.pending = [];
+    }
+  }.bind(this));
+
+  ws.on('close', function() {
+    this.open = false;
+    if (!this.closed) {
+      this.error_buffer.emit('error', 'websocket closed');
+      this.connect();
+    }
+  }.bind(this));
+
+  ws.on('error', function(err) {
+    this.open = false;
+    if (!this.closed) {
+      this.error_buffer.emit('error', err);
+      this.connect();
+    }
+  }.bind(this));
+
+  this.ws = ws;
+};
+
+OutputWebsocket.prototype.close = function(callback) {
+  logger.info('Closing websocket output to', this.host, this.port, 'ssl ' + this.ssl);
+  this.closed = true;
+  this.ws.close();
+  callback();
+};
+
+exports.create = function() {
+  return new OutputWebsocket();
+};

--- a/lib/outputs/output_websocket.js
+++ b/lib/outputs/output_websocket.js
@@ -94,3 +94,4 @@ OutputWebsocket.prototype.close = function(callback) {
 exports.create = function() {
   return new OutputWebsocket();
 };
+

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "zmq": "2.10.x",
     "moment": "2.9.x",
     "redis": "0.12.x",
+    "ws": "0.7.1",
     "oniguruma": "4.0.x",
     "msgpack": "0.2.6",
     "geoip-lite": "1.1.x",

--- a/test/test_421_websocket.js
+++ b/test/test_421_websocket.js
@@ -1,0 +1,106 @@
+var vows = require('vows-batch-retry'),
+  http = require('http'),
+  net = require('net'),
+  assert = require('assert'),
+  helper = require('./integration_helper.js');
+
+function createHttpTest(output_url, input_url, check_callback) {
+  return {
+    topic: function() {
+      var callback = this.callback;
+      var reqs = [];
+      helper.createAgent([
+        input_url,
+        'output://http_post://localhost:17876?serializer=json_logstash',
+      ], function(agent1) {
+        helper.createAgent([
+          'input://tcp://0.0.0.0:17874?type=pouet',
+          output_url,
+        ], function(agent2) {
+          var http_server = http.createServer(function(req, res) {
+            var body = '';
+            req.on('data', function(chunk) {
+              body += chunk;
+            });
+            req.on('end', function() {
+              reqs.push({
+                req: req,
+                body: body
+              });
+              res.writeHead(204);
+              res.end();
+              if (reqs.length === 2) {
+                agent2.close(function() {
+                  agent1.close(function() {
+                    http_server.close(function() {
+                      callback(null, reqs);
+                    });
+                  });
+                });
+              }
+            });
+          }).listen(17876);
+          var c1 = net.createConnection({
+            port: 17874
+          }, function() {
+            c1.write('toto\n');
+            setTimeout(function() {
+              c1.write('tata\n');
+              c1.end();
+            }, 10);
+          });
+        });
+      });
+    },
+
+    check: function(err, reqs) {
+      assert.ifError(err);
+      assert.equal(reqs.length, 2);
+      check_callback(reqs);
+    }
+  };
+}
+
+vows.describe('Integration Websocket :').addBatchRetry({
+  'websocket test raw': createHttpTest('output://websocket://127.0.0.1:17875?serializer=raw', 'input://websocket://0.0.0.0:17875?type=wspouet', function(reqs) {
+    assert.equal(reqs[0].req.method, 'POST');
+    assert.equal(reqs[0].req.headers['content-type'], 'application/json');
+    helper.checkResult(reqs[0].body, {
+      message: 'toto',
+      host: '127.0.0.1',
+      ws_port: 17875,
+      type: 'wspouet',
+      '@version': '1'
+    });
+    assert.equal(reqs[1].req.method, 'POST');
+    assert.equal(reqs[1].req.headers['content-type'], 'application/json');
+    helper.checkResult(reqs[1].body, {
+      message: 'tata',
+      host: '127.0.0.1',
+      ws_port: 17875,
+      type: 'wspouet',
+      '@version': '1'
+    });
+  }),
+}, 5, 20000).addBatchRetry({
+    'websocket test json': createHttpTest('output://websocket://localhost:17875?serializer=json_logstash', 'input://websocket://localhost:17875', function(reqs) {
+      assert.equal(reqs[0].req.method, 'POST');
+      assert.equal(reqs[0].req.headers['content-type'], 'application/json');
+      helper.checkResult(reqs[0].body, {
+        message: 'toto',
+        host: '127.0.0.1',
+        tcp_port: 17874,
+        type: 'pouet',
+        '@version': '1'
+      });
+      assert.equal(reqs[1].req.method, 'POST');
+      assert.equal(reqs[1].req.headers['content-type'], 'application/json');
+      helper.checkResult(reqs[1].body, {
+        message: 'tata',
+        host: '127.0.0.1',
+        tcp_port: 17874,
+        type: 'pouet',
+        '@version': '1'
+      });
+    }),
+  }, 5, 20000).export(module);

--- a/test/test_421_websocket.js
+++ b/test/test_421_websocket.js
@@ -4,7 +4,7 @@ var vows = require('vows-batch-retry'),
   assert = require('assert'),
   helper = require('./integration_helper.js');
 
-function createHttpTest(output_url, input_url, check_callback) {
+function setupTest(output_url, input_url, check_callback) {
   return {
     topic: function() {
       var callback = this.callback;
@@ -62,7 +62,7 @@ function createHttpTest(output_url, input_url, check_callback) {
 }
 
 vows.describe('Integration Websocket :').addBatchRetry({
-  'websocket test raw': createHttpTest('output://websocket://127.0.0.1:17875?serializer=raw', 'input://websocket://0.0.0.0:17875?type=wspouet', function(reqs) {
+  'websocket test raw': setupTest('output://websocket://127.0.0.1:17875?serializer=raw', 'input://websocket://0.0.0.0:17875?type=wspouet', function(reqs) {
     assert.equal(reqs[0].req.method, 'POST');
     assert.equal(reqs[0].req.headers['content-type'], 'application/json');
     helper.checkResult(reqs[0].body, {
@@ -83,7 +83,7 @@ vows.describe('Integration Websocket :').addBatchRetry({
     });
   }),
 }, 5, 20000).addBatchRetry({
-    'websocket test json': createHttpTest('output://websocket://localhost:17875?serializer=json_logstash', 'input://websocket://localhost:17875', function(reqs) {
+    'websocket test json': setupTest('output://websocket://localhost:17875?serializer=json_logstash', 'input://websocket://localhost:17875', function(reqs) {
       assert.equal(reqs[0].req.method, 'POST');
       assert.equal(reqs[0].req.headers['content-type'], 'application/json');
       helper.checkResult(reqs[0].body, {


### PR DESCRIPTION
We're using node-logstash to collect about 500GB of logs a day. We've used HTTP input/output until now because of firewall limitations, but noticed that the agent is taking a high toll on the CPU.

Websockets are like TCP connections, but they are firewall and proxy friendly - they begin as a regular HTTP connection that upgrades to a websocket. Where a firewall and/or a proxy may only allow for HTTP connections, websockets are a much faster and lighter option.
